### PR TITLE
Allow running tests from main directory

### DIFF
--- a/tests/testcontrol.py
+++ b/tests/testcontrol.py
@@ -18,115 +18,14 @@
 # along with pythonfilter.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import tempfile
+import shutil
 import unittest
+
 import courier.config
-
-
-courier.config.sysconfdir = 'tmp/configfiles'
-
-
 import courier.control
 
 
-message = {}
-message['xalias'] = {'control_paths': ['tmp/queuefiles/control-xalias'],
-                     'control_data': {'s': 'root@ascension.private.dragonsdawn.net',
-                                      'f': 'dns; localhost (localhost [127.0.0.1])',
-                                      'e': '',
-                                      'M': '000AF5D6.46A974C9.00002706',
-                                      'i': None,
-                                      't': '',
-                                      'E': '1186115401',
-                                      'p': '1185539401',
-                                      'W': '1185525001',
-                                      'w': False,
-                                      '8': False,
-                                      'm': False,
-                                      'V': False,
-                                      'v': None,
-                                      'X': None,
-                                      'U': '',
-                                      'u': 'local',
-                                      'T': False,
-                                      'r': [['".xalias/testalias@ascension+2eprivate+2edragonsdawn+2enet"@ascension.private.dragonsdawn.net',
-                                             'rfc822;testalias@ascension.private.dragonsdawn.net',
-                                             '']]},
-                     'senders_ip': '127.0.0.1'}
-message['duplicate'] = {'control_paths': ['tmp/queuefiles/control-duplicate'],
-                        'control_data': {'s': 'root@ascension.private.dragonsdawn.net',
-                                         'f': 'dns; localhost (localhost [127.0.0.1])',
-                                         'e': '',
-                                         'M': '000AF5DB.46B0E301.0000778F',
-                                         'i': None,
-                                         't': '',
-                                         'E': '1186602369',
-                                         'p': '1186026369',
-                                         'W': '1186011969',
-                                         'w': False,
-                                         '8': False,
-                                         'm': False,
-                                         'V': False,
-                                         'v': None,
-                                         'X': None,
-                                         'U': '',
-                                         'u': 'local',
-                                         'T': False,
-                                         'r': [['gordon@ascension.private.dragonsdawn.net',
-                                                '',
-                                                ''],
-                                               ['gordon@ascension.private.dragonsdawn.net',
-                                                'rfc822;postmaster@ascension.private.dragonsdawn.net',
-                                                '']]},
-                        'senders_ip': '127.0.0.1'}
-message['ldapalias'] = {'control_paths':  ['tmp/queuefiles/control-ldapalias'],
-                        'control_data': {'s': 'root@ascension.private.dragonsdawn.net',
-                                         'f': 'dns; localhost (localhost [127.0.0.1])',
-                                         'e': '',
-                                         'M': '000AF5D6.46B75799.00003C4B',
-                                         'i': None,
-                                         't': '',
-                                         'E': '1187025433',
-                                         'p': '1186449433',
-                                         'W': '1186435033',
-                                         'w': False,
-                                         '8': False,
-                                         'm': False,
-                                         'V': False,
-                                         'v': None,
-                                         'X': None,
-                                         'U': '',
-                                         'u': 'local',
-                                         'T': False,
-                                         'r': [['rob@ascension.private.dragonsdawn.net',
-                                                '',
-                                                'N'],
-                                               ['gordon@ascension.private.dragonsdawn.net',
-                                                '',
-                                                'N']]},
-                        'senders_ip': '127.0.0.1'}
-message['iso-8859-2'] = {'control_paths': ['tmp/queuefiles/control-iso-8859-2'],
-                         'control_data': {'s': 'root@ascension.private.dragonsdawn.net',
-                                          'f': 'dns; localhost (localhost [127.0.0.1])',
-                                          'e': '',
-                                          'M': '000AF5DB.46B0E301.0000778F',
-                                          'i': None,
-                                          't': '',
-                                          'E': '1186602369',
-                                          'p': '1186026369',
-                                          'W': '1186011969',
-                                          'w': False,
-                                          '8': False,
-                                          'm': False,
-                                          'V': False,
-                                          'v': None,
-                                          'X': None,
-                                          'U': '',
-                                          'u': 'local',
-                                          'T': False,
-                                          'r': [['(malformed utf8):t%EBst-is%F6-8859@ascension.private.dragonsdawn.net',
-                                                 '',
-                                                 '']]},
-                         'senders_ip': '127.0.0.1'}
 rcpt_a = ['testcontrol@ascension.private.dragonsdawn.net',
           '',
           '']
@@ -138,15 +37,116 @@ rcpt_b = ['testcontrol@ascension.private.dragonsdawn.net',
 class TestCourierControl(unittest.TestCase):
 
     def setUp(self):
-        os.mkdir('tmp')
-        os.system('cp -a queuefiles tmp/queuefiles')
-        os.system('cp -a configfiles tmp/configfiles')
+        self.tmpdir = tempfile.mkdtemp()
+        shutil.copytree(f"{os.path.dirname(__file__)}/queuefiles", f"{self.tmpdir}/queuefiles")
+        shutil.copytree(f"{os.path.dirname(__file__)}/configfiles", f"{self.tmpdir}/configfiles")
+        courier.config.sysconfdir = f'{self.tmpdir}/configfiles'
+
+        self.message = {}
+        self.message['xalias'] = {'control_paths': [self.tmpdir + '/queuefiles/control-xalias'],
+                                  'control_data': {'s': 'root@ascension.private.dragonsdawn.net',
+                                                   'f': 'dns; localhost (localhost [127.0.0.1])',
+                                                   'e': '',
+                                                   'M': '000AF5D6.46A974C9.00002706',
+                                                   'i': None,
+                                                   't': '',
+                                                   'E': '1186115401',
+                                                   'p': '1185539401',
+                                                   'W': '1185525001',
+                                                   'w': False,
+                                                   '8': False,
+                                                   'm': False,
+                                                   'V': False,
+                                                   'v': None,
+                                                   'X': None,
+                                                   'U': '',
+                                                   'u': 'local',
+                                                   'T': False,
+                                                   'r': [['".xalias/testalias@ascension+2eprivate+2edragonsdawn+2enet"@ascension.private.dragonsdawn.net',
+                                                          'rfc822;testalias@ascension.private.dragonsdawn.net',
+                                                          '']]},
+                                  'senders_ip': '127.0.0.1'}
+        self.message['duplicate'] = {'control_paths': [self.tmpdir + '/queuefiles/control-duplicate'],
+                                     'control_data': {'s': 'root@ascension.private.dragonsdawn.net',
+                                                      'f': 'dns; localhost (localhost [127.0.0.1])',
+                                                      'e': '',
+                                                      'M': '000AF5DB.46B0E301.0000778F',
+                                                      'i': None,
+                                                      't': '',
+                                                      'E': '1186602369',
+                                                      'p': '1186026369',
+                                                      'W': '1186011969',
+                                                      'w': False,
+                                                      '8': False,
+                                                      'm': False,
+                                                      'V': False,
+                                                      'v': None,
+                                                      'X': None,
+                                                      'U': '',
+                                                      'u': 'local',
+                                                      'T': False,
+                                                      'r': [['gordon@ascension.private.dragonsdawn.net',
+                                                             '',
+                                                             ''],
+                                                            ['gordon@ascension.private.dragonsdawn.net',
+                                                             'rfc822;postmaster@ascension.private.dragonsdawn.net',
+                                                             '']]},
+                                     'senders_ip': '127.0.0.1'}
+        self.message['ldapalias'] = {'control_paths': [self.tmpdir + '/queuefiles/control-ldapalias'],
+                                     'control_data': {'s': 'root@ascension.private.dragonsdawn.net',
+                                                      'f': 'dns; localhost (localhost [127.0.0.1])',
+                                                      'e': '',
+                                                      'M': '000AF5D6.46B75799.00003C4B',
+                                                      'i': None,
+                                                      't': '',
+                                                      'E': '1187025433',
+                                                      'p': '1186449433',
+                                                      'W': '1186435033',
+                                                      'w': False,
+                                                      '8': False,
+                                                      'm': False,
+                                                      'V': False,
+                                                      'v': None,
+                                                      'X': None,
+                                                      'U': '',
+                                                      'u': 'local',
+                                                      'T': False,
+                                                      'r': [['rob@ascension.private.dragonsdawn.net',
+                                                             '',
+                                                             'N'],
+                                                            ['gordon@ascension.private.dragonsdawn.net',
+                                                             '',
+                                                             'N']]},
+                                     'senders_ip': '127.0.0.1'}
+        self.message['iso-8859-2'] = {'control_paths': [self.tmpdir + '/queuefiles/control-iso-8859-2'],
+                                      'control_data': {'s': 'root@ascension.private.dragonsdawn.net',
+                                                       'f': 'dns; localhost (localhost [127.0.0.1])',
+                                                       'e': '',
+                                                       'M': '000AF5DB.46B0E301.0000778F',
+                                                       'i': None,
+                                                       't': '',
+                                                       'E': '1186602369',
+                                                       'p': '1186026369',
+                                                       'W': '1186011969',
+                                                       'w': False,
+                                                       '8': False,
+                                                       'm': False,
+                                                       'V': False,
+                                                       'v': None,
+                                                       'X': None,
+                                                       'U': '',
+                                                       'u': 'local',
+                                                       'T': False,
+                                                       'r': [['(malformed utf8):t%EBst-is%F6-8859@ascension.private.dragonsdawn.net',
+                                                              '',
+                                                              '']]},
+                                      'senders_ip': '127.0.0.1'}
 
     def tearDown(self):
-        os.system('rm -rf tmp')
+        shutil.rmtree(self.tmpdir)
 
     def testGetLines(self):
-        for x in message.values():
+        for x in self.message.values():
             # Deprecated function test
             self.assertEqual(courier.control.getLines(x['control_paths'], 's'),
                              [x['control_data']['s']])
@@ -164,7 +164,7 @@ class TestCourierControl(unittest.TestCase):
                              [x['control_data']['e']])
 
     def testGetSendersMta(self):
-        for x in message.values():
+        for x in self.message.values():
             # Deprecated function test
             self.assertEqual(courier.control.getSendersMta(x['control_paths']),
                              x['control_data']['f'])
@@ -174,7 +174,7 @@ class TestCourierControl(unittest.TestCase):
                              x['control_data']['f'])
 
     def testGetSendersIP(self):
-        for x in message.values():
+        for x in self.message.values():
             # Deprecated function test
             self.assertEqual(courier.control.getSendersIP(x['control_paths']),
                              x['senders_ip'])
@@ -184,7 +184,7 @@ class TestCourierControl(unittest.TestCase):
                              x['senders_ip'])
 
     def testGetSender(self):
-        for x in message.values():
+        for x in self.message.values():
             # Deprecated function test
             self.assertEqual(courier.control.getSender(x['control_paths']),
                              x['control_data']['s'])
@@ -194,7 +194,7 @@ class TestCourierControl(unittest.TestCase):
                              x['control_data']['s'])
 
     def testGetRecipients(self):
-        for x in message.values():
+        for x in self.message.values():
             # Deprecated function test
             self.assertEqual(courier.control.getRecipients(x['control_paths']),
                              [y[0] for y in x['control_data']['r']])
@@ -204,7 +204,7 @@ class TestCourierControl(unittest.TestCase):
                              [y[0] for y in x['control_data']['r']])
 
     def testGetRecipientsData(self):
-        for x in message.values():
+        for x in self.message.values():
             # Deprecated function test
             self.assertEqual(courier.control.getRecipientsData(x['control_paths']),
                              x['control_data']['r'])
@@ -214,7 +214,7 @@ class TestCourierControl(unittest.TestCase):
                              x['control_data']['r'])
 
     def testGetControlData(self):
-        for x in message.values():
+        for x in self.message.values():
             # Deprecated function test
             self.assertEqual(courier.control.getControlData(x['control_paths']),
                              x['control_data'])
@@ -224,7 +224,7 @@ class TestCourierControl(unittest.TestCase):
                              x['control_data'])
 
     def testAddRecipient(self):
-        for x in message.values():
+        for x in self.message.values():
             # Deprecated function test
             # FIXME: addRecipient isn't included in the new test here, but it is in
             # testDelRecipient.  To be fixed when backward compatibility is dropped.
@@ -238,7 +238,7 @@ class TestCourierControl(unittest.TestCase):
                              x['control_data']['r'] + [rcpt_a])
 
     def testAddRecipientData(self):
-        for x in message.values():
+        for x in self.message.values():
             # Deprecated function test
             # FIXME: addRecipientData isn't included in the new test here, but it is in
             # testDelRecipientData.  To be fixed when backward compatibility is dropped.
@@ -252,7 +252,7 @@ class TestCourierControl(unittest.TestCase):
                              x['control_data']['r'] + [rcpt_b])
 
     def testDelRecipient(self):
-        for x in message.values():
+        for x in self.message.values():
             # Deprecated function test
             courier.control.addRecipient(x['control_paths'],
                                          rcpt_a[0])
@@ -274,7 +274,7 @@ class TestCourierControl(unittest.TestCase):
                              x['control_data']['r'])
 
     def testDelRecipientData(self):
-        for x in message.values():
+        for x in self.message.values():
             # Deprecated function test
             courier.control.addRecipientData(x['control_paths'],
                                              rcpt_b)

--- a/tests/testmoduleconfig.py
+++ b/tests/testmoduleconfig.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with pythonfilter.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import unittest
 import courier.config
 
@@ -24,7 +25,7 @@ import courier.config
 class TestModuleConfig(unittest.TestCase):
 
     def testLoader(self):
-        courier.config._standard_config_paths = './configfiles/pythonfilter-modules.conf'
+        courier.config._standard_config_paths = f"{os.path.dirname(__file__)}/configfiles/pythonfilter-modules.conf"
         config = courier.config.getModuleConfig('test1')
         self.assertEqual(config['name1'], 'value1')
         self.assertEqual(config['name2'], 'value2')
@@ -58,7 +59,7 @@ class TestModuleConfig(unittest.TestCase):
 
 
     def testApply(self):
-        courier.config._standard_config_paths = './configfiles/pythonfilter-modules.conf'
+        courier.config._standard_config_paths = f"{os.path.dirname(__file__)}/configfiles/pythonfilter-modules.conf"
         config = {}
         courier.config.applyModuleConfig('test1', config)
         self.assertEqual(config['name1'], 'value1')

--- a/tests/testxfilter.py
+++ b/tests/testxfilter.py
@@ -18,6 +18,8 @@
 # along with pythonfilter.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
+import tempfile
+import shutil
 import unittest
 import courier.xfilter
 
@@ -25,18 +27,20 @@ import courier.xfilter
 class TestXfilter(unittest.TestCase):
 
     def setUp(self):
-        os.mkdir('tmp')
-        os.system('cp queuefiles/control-iso-8859-2 tmp')
-        os.system('cp queuefiles/data-iso-8859-2 tmp')
+        self.tmpdir = tempfile.mkdtemp()
+        shutil.copyfile(f'{os.path.dirname(__file__)}/queuefiles/control-iso-8859-2',
+                        f'{self.tmpdir}/control-iso-8859-2')
+        shutil.copyfile(f'{os.path.dirname(__file__)}/queuefiles/data-iso-8859-2',
+                        f'{self.tmpdir}/data-iso-8859-2')
 
     def tearDown(self):
-        os.system('rm -rf tmp')
+        shutil.rmtree(self.tmpdir)
 
     def testxfilter(self):
         # Ensure that xfilter can deserialize and serialize a message
         mfilter = courier.xfilter.XFilter('testxfilter',
-                                          'tmp/data-iso-8859-2',
-                                          ['tmp/control-iso-8859-2'])
+                                          f'{self.tmpdir}/data-iso-8859-2',
+                                          [f'{self.tmpdir}/control-iso-8859-2'])
         submit_val = mfilter.submit()
         self.assertEqual(submit_val, '')
 
@@ -44,8 +48,8 @@ class TestXfilter(unittest.TestCase):
         # Ensure that xfilter can deserialize and serialize a message
         # containing non-ascii data but no CTE header.
         mfilter = courier.xfilter.XFilter('testxfilter',
-                                          'tmp/data-iso-8859-2',
-                                          ['tmp/control-iso-8859-2'])
+                                          f'{self.tmpdir}/data-iso-8859-2',
+                                          [f'{self.tmpdir}/control-iso-8859-2'])
         mmsg = mfilter.get_message()
         del mmsg['Content-Transfer-Encoding']
         submit_val = mfilter.submit()


### PR DESCRIPTION
This changes a few more tests to use proper temp directories and allow running them from the main directory path.

(There are still a few left that are a bit less trivial to change - will look more into that another time.)