### PR TITLE
Run pycodestyle and pyflakes in CI

### DIFF
--- a/.github/workflows/runci.yml
+++ b/.github/workflows/runci.yml
@@ -16,9 +16,13 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install pytest
+      - name: Install test and linting tools
         run: |
-          pip install pytest
+          pip install pytest pycodestyle pyflakes
       - name: Run tests
         run: |
           pytest -v
+      - name: Check Codingstyle
+        run: |
+          pycodestyle --ignore=E501,E722,W503,W504 . dropmsg pythonfilter pythonfilter-quarantine
+          pyflakes . dropmsg pythonfilter pythonfilter-quarantine


### PR DESCRIPTION
This adds some codingstyle checks to the CI.

It runs `pycodestyle`, which is the common tool to check for Python's PEP8 standard codingstyle (previously known as `pep8`).

I have disabled the following rules for now:
* E501 - long lines, there are a couple in the code.
* E722 - bare except. There are plenty in the code. Ideally, one would only catch specific exceptions, but this is often quite troublesome to implement as one has to know all the possible exceptions in advance.
* W503/W504 - those two are incompatible, so you can only have one. They decide whether logical keywords (and/or) in a multiline if clause are on the next line or not. Both appear in the code, and there's no strong advantage of one over the other.

It also runs pyflakes, which detects unused variables and related issues.